### PR TITLE
Added option to specify additional TapPackages to install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
   test-linux-packages:
     runs-on: ubuntu-20.04
-    name: Test Linux
+    name: Test Linux (Packages)
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,18 @@ jobs:
         with:
           version: '9.17.0'
 
+  test-linux-packages:
+    runs-on: ubuntu-20.04
+    name: Test Linux
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: ./ # Uses an action in the root directory
+        id: setup
+        with:
+          version: '9.17.0'
+          packages: 'Demonstration,PackagePublish:rc,TUI:any'
+
   test-win:
     runs-on: windows-2022
     name: Test Windows

--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ Here is a small example of how to use the action.
 ## Arguments
 There are a few arguments to help you select the right version of OpenTAP to install.
 
-- `version` - Defaults to the latest release
+- `version` Defaults to the latest release
 - `architecture` - Defaults to the architecture of the runner  
 - `os` - Defaults to the OS of the runner
-- `packages` - a list of additional packages to install. Format: `<name1>:<version1>,<name2>:<version2>`
+- `packages` - a list of additional packages to install. Format: `<name1>:<version1>,<name2>:<version2>`. This option requires `version` to be 9.17 or greater.

--- a/Readme.md
+++ b/Readme.md
@@ -15,4 +15,4 @@ There are a few arguments to help you select the right version of OpenTAP to ins
 - `version` - Defaults to the latest release
 - `architecture` - Defaults to the architecture of the runner  
 - `os` - Defaults to the OS of the runner
-- `packages` - a list of additional packages to install
+- `packages` - a list of additional packages to install. Format: `<name1>:<version1>,<name2>:<version2>`

--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@ GitHub action that installs everything needed to run OpenTAP.
 ## Usage
 Here is a small example of how to use the action.
 ```yml
-- uses: StefanHolst/setup-opentap@v1.0
+- uses: opentap/setup-opentap@v1.0
   with:
     version: 9.17.0
 ```
@@ -13,5 +13,6 @@ Here is a small example of how to use the action.
 There are a few arguments to help you select the right version of OpenTAP to install.
 
 - `version` - Defaults to the latest release
-- `architecture` - Defaults to x64
-- `os` - Defaults to Linux
+- `architecture` - Defaults to the architecture of the runner  
+- `os` - Defaults to the OS of the runner
+- `packages` - a list of additional packages to install

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   os:
     description: 'OS of OpenTAP to use'
     required: false
+  packages:
+    description: 'Additional packages to install. Format: <name1>:<version1>,<name2>:<version2>'
+    required: false
 runs:
   using: 'node12'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ async function main() {
       }
       const imageJson = JSON.stringify(image, null, 2);
       fs.writeFileSync("image.json", imageJson);
-      core.info("Image: " + imageJson);
+      core.debug("Image: " + imageJson);
       await exec.exec('tap', ["image", "install", "image.json", "--non-interactive", "--merge", "--force"])
     }
 

--- a/index.js
+++ b/index.js
@@ -45,16 +45,17 @@ async function main() {
     core.addPath(destDir)
     
     // Install packages
-    core.info("Packages: " + core.getInput('packages'));
-    var pkgSpecs = core.getInput('packages').split(",");
-    if (pkgSpecs) {
-      var image = { Repositories: ["packages.opentap.io"], Packages: [] };
+    if (core.getInput('packages')) {
+      var pkgSpecs = core.getInput('packages').split(",");
+      var image = { Packages: [], Repositories: ["packages.opentap.io"] };
       for (let i = 0; i < pkgSpecs.length; i++) {
         const name = pkgSpecs[i].split(":")[0];
         const ver = pkgSpecs[i].split(":")[1];
         image.Packages.push({ Name: name, Version: ver });
       }
-      fs.writeFileSync("image.json", JSON.stringify(image));
+      const imageJson = JSON.stringify(image, null, 2);
+      fs.writeFileSync("image.json", imageJson);
+      core.info("Image: " + imageJson);
       await exec.exec('tap', ["image", "install", "image.json", "--non-interactive", "--merge", "--force"])
     }
 


### PR DESCRIPTION
Could be useful for things like publishing packages:

```yaml
  publish:
    runs-on: ubuntu-20.04
    name: Publish OpenTAP Package 
    steps:
      - uses: actions/download-artifact@v2
        with:
          name: package
      - uses: openta/setup-opentap
        with:
          version: 9.17.0
          packages: PackagePublish:rc
      - run: tap package publish *.TapPackage
```
