### PR TITLE
Add fallback zip extracter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,18 @@ jobs:
         with:
           version: '9.17.0'
 
+  test-linux-container:
+    runs-on: ubuntu-20.04
+    container: mcr.microsoft.com/dotnet/sdk:8.0
+    name: Test Linux Container
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: ./ # Uses an action in the root directory
+        id: setup
+        with:
+          version: '9.17.0'
+
   test-linux-packages:
     runs-on: ubuntu-20.04
     name: Test Linux (Packages)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           version: '9.17.0'    
 
   test-macos:
-    runs-on: macos-11
+    runs-on: macos-14
     name: Test MacOS
     steps:
       - name: Checkout
@@ -47,7 +47,7 @@ jobs:
           version: '9.17.0'
 
   test-macos-packages:
-    runs-on: macos-11
+    runs-on: macos-14
     name: Test MacOS (Packages)
     steps:
       - name: Checkout


### PR DESCRIPTION
This makes the action work on e.g. "mcr.microsoft.com/dotnet/sdk:8.0" which has powershell, but not unzip